### PR TITLE
Frame refactor

### DIFF
--- a/htpt/frame.py
+++ b/htpt/frame.py
@@ -16,6 +16,7 @@ class FramingException(Exception):
 
 
 class SeqNumber():
+  # initialize this to -1 so that the first sequence number comes out to 0
   _seqNum = -1
   _lock = threading.Lock()
   @classmethod
@@ -60,24 +61,37 @@ class SessionID():
     cls._lock.release()
     return cls._sessionID
 
-class Assemble():
+class Assembler():
   """Class to Assemble a data frame with headers before sending to encoder"""
+
   def __init__(self, sessionID=0):
     """Initialize SeqNumber object and sessionID"""
+    # initialize the seq number to 0 and start sending frames
     self.seqNum = SeqNumber()
     self.setSessionID(sessionID)
 
   def setSessionID(self, sessionID):
-    """Function to allow upper abstraction to set sessionID for sender"""
+    """
+    Set the session ID for this sender
+
+    Note: this should be called by the client upon receiving the ACK
+    packet (first packet) back from the server. The client should get
+    the session ID from the Disassembler and add it here
+
+    """
     self.sessionID = sessionID
 
   def getSessionID(self):
-    """Function to retrieve the client's or server's session ID
+    """
+    Get the sessionID for this assembler
 
-    server assigns a new session ID when a new client connects to
-    it. server maintains sessionID on its end. client should retrieve
-    sessionID from the ACK packet (from SYN-ACK) and set it as
-    self.sessionID"""
+    Note: this is not an instance of the SessionID class which
+    generates unique sessionIDs. This stores the generated ID.
+
+    Note: this function will be called when creating the flags for an
+    outgoing frame
+
+    """
     return self.sessionID
 
   def generateFlags(self, **kwargs):
@@ -141,31 +155,13 @@ class Assemble():
     return frame
 
 
-class Disassemble:
+class Disassembler:
   """Class to Disassemble a decoded packet into headers+data before sending to buffers"""
   def __init__(self, callback):
     self.callback = callback
-    # allocate a buffer to receive data and flush it
+    # allocate a buffer to receive data
     self.buffer = Buffer()
-
     self.buffer.addCallback(self.callback)
-
-  def initServerConnection(self, frame):
-    """getting password from url; returns data"""
-    #get the data
-    headers = frame[:4]
-    self.retrieveHeaders(headers)
-    data = frame[4:]
-
-    #initialize the session id
-    #this should be done at higher layer using
-    #Assembler.setSessionID(sessionID.getSessionIDAndIncrement())
-    #should be done at the server only if client is new and SYN=1
-
-    #set the seqnumber to the value from the frame -- Ben
-    #no need to do this as seq num start from 0 and increment
-
-    return data
 
   def disassemble(self, frame):
     """
@@ -187,26 +183,28 @@ class Disassemble:
     data = frame[4:]
 
     # receive, reorder and flush at buffer
+#    print "In disassemble: {} {}".format(data, self.buffer.buffer)
     self.buffer.recvData(data, self.seqNum)
     return data
 
   def retrieveHeaders(self, headers):
     """Extract 4 byte header to seqNum, sessionID, Flags"""
 
-    headerTuple = struct.unpack('!HBB', headers)
-    self.seqNum = headerTuple[0]
+    seqNum, sessionID, flags = parseHeaders(headers)
+
+    self.seqNum = seqNum
 
     # retrieve flags
-    self.flags = headerTuple[2]
+    self.flags = flags
 
     # retrieved header sets the session ID if SYN flag is set
     # also add a check: if SYN flag not checked then
     # self.sessionid == headerTuple[1]
 
     #if self.flags & (1<<7):
-    self.setSessionID(headerTuple[1])
+    self.setSessionID(sessionID)
 
-    # Future: if flags = '1000' i.e. more_data, then send pull_request to
+    # TODO: if flags = '1000' i.e. more_data, then send pull_request to
     # server for more data
 
   def getSessionID(self):
@@ -219,3 +217,48 @@ class Disassemble:
 
   #def flush(self):
   #  self.buffer.flush()
+
+def parseHeaders(headers):
+  """ Parse the headers and return the values"""
+  headerTuple = struct.unpack('!HBB', headers)
+  seqNum = headerTuple[0]
+  sessionID = headerTuple[1]
+  flags = headerTuple[2]
+  return seqNum, sessionID, flags
+
+def initServerConnection(frame, passwords, callback):
+  """
+  Respond to an initialization request from a client
+
+  1. ensure that the password is correct-> do this by verifying that
+  it matches one of the passwords in the list
+  2. initialize the sessionID for this client
+  3. return an assembler and disassembler for this client
+
+  Note: this is a module method, it is not associated with an object
+
+  """
+
+  # parse the headers
+  headers = frame[:4]
+  seqNum, sessionID, flags = parseHeaders(headers)
+  data = frame[4:]
+
+  # Part 1: validate the password
+  # if this is a bad login attempt, then return False
+  if data not in passwords:
+    print "len: {} frame: {} seqNum: {} sessionID: {} flags: {} ".format(len(frame), frame, str(seqNum), str(sessionID), str(flags))
+    return False, False
+
+  # Part 2: initialize the session id using the SessionID class methods
+  sessionID = SessionID.getSessionIDAndIncrement()
+
+  # Part 3: return an assembler and disassembler for the client
+  sender = Assembler()
+#  print "seqNum: {}".format(sender.seqNum._seqNum)
+  sender.setSessionID(sessionID)
+  receiver = Disassembler(callback)
+  receiver.setSessionID(sessionID)
+
+  return sender, receiver
+

--- a/htpt/frame.py
+++ b/htpt/frame.py
@@ -16,35 +16,49 @@ class FramingException(Exception):
 
 
 class SeqNumber():
-  def __init__(self, seqNum = 0):
-    """Initialize the framing package with the given sequence number"""
-    self.seqNum = seqNum
-    self.initialized = True
-    self._lock = threading.Lock()
+  _seqNum = -1
+  _lock = threading.Lock()
+  @classmethod
+  def setSeqNum(cls, seqNum):
+    cls._lock.acquire()
+    cls._seqNum = seqNum
+    cls._lock.release()
 
-  def getSequenceAndIncrement(self):
-    """In a thread safe manner, get the sequence number"""
-    self._lock.acquire()
-    self.seqNum = ((self.seqNum + 1) % MAX_SEQ_NUM)
-    self._lock.release()
-    return self.seqNum
+  @classmethod  
+  def getSequenceAndIncrement(cls):
+    """
+    In a thread safe manner, get the sequence number and increment.
+    
+    Note: this function is called only when a new client connects
+    """
+    cls._lock.acquire()
+    cls._seqNum = ((cls._seqNum + 1) % MAX_SEQ_NUM)
+    cls._lock.release()
+    return cls._seqNum
 
 class SessionID():
   """Class to generate a new session ID when a new client connects to the server"""
-  def __init__(self, sessionID=0):
-    """Initialize the new session ID"""
-    self.sessionID = sessionID
-    self.initialized = True
-    self._lock = threading.Lock()
+  
+  _sessionID = 0
+  _lock = threading.Lock()
+  @classmethod
+  def setSessionID(cls, sessionID):
+    cls._lock.acquire()
+    cls._sessionID = sessionID
+    cls._lock.release()
 
-  def getSessionIDAndIncrement(self):
-    """In a thread safe manner, get the session ID
+  @classmethod  
+  def getSessionIDAndIncrement(cls):
+    """
+    In a thread safe manner, get the session ID.
+    
+    Note: this function is called only when a new client connects
 
-    this function is called only when a new client connects"""
-    self._lock.acquire()
-    self.sessionID = ((self.sessionID + 1) % MAX_SESSION_NUM)
-    self._lock.release()
-    return self.sessionID
+    """
+    cls._lock.acquire()
+    cls._sessionID = ((cls._sessionID + 1) % MAX_SESSION_NUM)
+    cls._lock.release()
+    return cls._sessionID
 
 class Assemble():
   """Class to Assemble a data frame with headers before sending to encoder"""

--- a/htpt/htpt.py
+++ b/htpt/htpt.py
@@ -44,7 +44,6 @@ class HTPT():
   def run_client(self):
     # initialize the connection
     self.assembler = frame.Assemble()
-    self.assembler.seqNum = frame.SeqNumber(-1)
     # bind to a local address and wait for Tor to connect
     self.torBinder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     self.torBinder.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
@@ -54,7 +53,6 @@ class HTPT():
 
     #now that we have a Tor connection, start sending data to server
     self.bridgeConnect(TOR_BRIDGE_ADDRESS, TOR_BRIDGE_PASSWORD)
-    self.assembler.seqNum = frame.SeqNumber(-1)
     self.timeout = datetime.now()
 
     while 1:
@@ -180,7 +178,6 @@ def processRequest():
           htptObject.assembler.setSessionID(sessionID)
           htptObject.disassembler.setSessionID(sessionID)
           #we initialize it to start sending with seq number 1
-          htptObject.assembler.seqNum = frame.SeqNumber(-1)
           #send back a blank image with the new session id
           framed = htptObject.assembler.assemble('')
           image = imageEncode.encode(framed, 'png')
@@ -237,7 +234,6 @@ if __name__ == '__main__':
     # initialize the connection
     htptObject.sessionIDs = frame.SessionID()
     htptObject.assembler = frame.Assemble()
-    htptObject.assembler.seqNum = frame.SeqNumber(-1)
     # bind to a local address and wait for Tor to connect
     htptObject.torBinder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     htptObject.torBinder.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)


### PR DESCRIPTION
Initial refactoring for the framing and buffer code. This code makes the interface cleaner and resolves some bugs. This is a partial solution to issue 28
## Changes

buffer.py: 
1. correctly sets the min and max seq number for the window. This resolves several bugs related to how data is queued in the buffer.
2. added functionality to let the buffer start numbering at an arbitrary sequence number

frame.py:
1. Refactored SeqNum and SessionID to use class methods. This establishes more consistency in the sequence numbers and ensures that the SessionIDs will be unique for the server when the server generates them. This code may need to be adjusted to support multiple sequence numbers on the server side.
2. Split some of the functionality of Dissambler.retrieveHeaders() out of the function. Added a module function which will split the headers up and which allows the headers to be examined without changing the state of a Disassembler.
3. Moved initServerConnection out of the Disassembler so that it can return an assembler and a dissassembler if the connection correctly authenticates.
## Functionality still to be added:

Make use of flags, specifically SYN and MORE
